### PR TITLE
DataCollection and Rb::InstanceChooser fixes (more details inside)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.3 - DEV
+===============
+* Fixed Rb::InstanceChooser not to accept a string parameter, only lists
+* Fixed a bug where Rb::InstanceChooser didn't handle pointers to lists properly
+
 v0.2 - 20140610
 ===============
 * setup.py changes for PIP
@@ -6,3 +11,4 @@ v0.2 - 20140610
 v0.1 - 20140610
 ===============
 * Initial release
+

--- a/rainbow/cloudformation.py
+++ b/rainbow/cloudformation.py
@@ -92,7 +92,12 @@ class Cloudformation(object):
 
         parameters = {}
         for parameter in template.get('Parameters', []):
-            parameters[parameter] = datasource_collection.get_parameter_recursive(parameter)
+            parameter_value = datasource_collection.get_parameter_recursive(parameter)
+
+            if hasattr(parameter_value, '__iter__'):
+                parameter_value = ', '.join(map(str, parameter_value))
+
+            parameters[parameter] = parameter_value
 
         return parameters
 

--- a/rainbow/datasources/base.py
+++ b/rainbow/datasources/base.py
@@ -107,13 +107,9 @@ class DataSourceCollection(list):
 
             return self.get_parameter_recursive(parameter)
         elif hasattr(parameter, '__iter__'):
-            # iterable, return a comma separated list
+            # resolve iterables and convert to a list
 
-            # if the iterable contains more pointers, resolve them and convert to a list
-            parameter = [self.get_parameter_recursive(i) if isinstance(i, DataCollectionPointer) else i
-                         for i in parameter]
-
-            return ", ".join([str(i) for i in parameter])
+            return [self.get_parameter_recursive(i) if isinstance(i, DataCollectionPointer) else i for i in parameter]
         else:
             # regular parameter, return as is.
 

--- a/rainbow/preprocessor/instance_chooser.py
+++ b/rainbow/preprocessor/instance_chooser.py
@@ -90,8 +90,11 @@ def instance_chooser(preprocessor, instance_types):
     :rtype: str
     """
 
+    if isinstance(instance_types, DataCollectionPointer):
+        instance_types = preprocessor.datasource_collection.get_parameter_recursive(instance_types)
+
     if not hasattr(instance_types, '__iter__'):
-        instance_types = [instance_types]
+        raise InvalidInstanceException('Instance types should be an iterable (a list)')
 
     # resolve pointers if relevant
     for i, v in enumerate(instance_types):

--- a/tests/datasources/a.yaml
+++ b/tests/datasources/a.yaml
@@ -11,3 +11,6 @@ item7: item4
 a_str: foobar
 shared: from a
 c1large: c1.large
+PossibleInstances:
+    - c3.large
+    - c1.medium

--- a/tests/main/simpletemplate.yaml
+++ b/tests/main/simpletemplate.yaml
@@ -1,6 +1,0 @@
-Resources:
-  MyLovelyResources:
-    Properties:
-      MyProperty: value
-      AnotherProperty: value2
-    Type: AWS::Dummy::DummyResource

--- a/tests/preprocessor/instance_chooser2.yaml
+++ b/tests/preprocessor/instance_chooser2.yaml
@@ -1,4 +1,4 @@
 Resources:
   Type: AWS::EC2::Instance
   Properties:
-    InstanceType: {'Rb::InstanceChooser': 'c3.large'}
+    InstanceType: {'Rb::InstanceChooser': ['c3.large']}

--- a/tests/preprocessor/instance_chooser3.yaml
+++ b/tests/preprocessor/instance_chooser3.yaml
@@ -1,4 +1,4 @@
 Resources:
   Type: AWS::EC2::Instance
   Properties:
-    InstanceType: {'Rb::InstanceChooser': 'nosuchinstance'}
+    InstanceType: {'Rb::InstanceChooser': ['nosuchinstance']}

--- a/tests/preprocessor/instance_chooser4.yaml
+++ b/tests/preprocessor/instance_chooser4.yaml
@@ -1,0 +1,4 @@
+Resources:
+  Type: AWS::EC2::Instance
+  Properties:
+    InstanceType: {'Rb::InstanceChooser': $PossibleInstances}

--- a/tests/templates/simpletemplate.yaml
+++ b/tests/templates/simpletemplate.yaml
@@ -1,0 +1,9 @@
+Parameters:
+  a_list: {Type: CommaDelimitedList}
+  b_list: {Type: CommaDelimitedList}
+Resources:
+  MyLovelyResource:
+    Properties:
+      MyProperty: {'Ref': 'a_list'}
+      AnotherProperty: value2
+    Type: AWS::Dummy::DummyResource

--- a/tests/test_cloudformation.py
+++ b/tests/test_cloudformation.py
@@ -1,0 +1,30 @@
+from unittest import TestCase
+from rainbow.datasources import DataSourceCollection
+from rainbow.preprocessor import Preprocessor
+from rainbow.preprocessor.preprocessor_exceptions import InvalidPreprocessorFunctionException
+from rainbow.preprocessor.instance_chooser import InvalidInstanceException
+from rainbow.yaml_loader import RainbowYamlLoader
+from rainbow.cloudformation import Cloudformation
+from rainbow.templates import TemplateLoader
+
+__author__ = 'omrib'
+
+
+class TestCloudformation(TestCase):
+    def setUp(self):
+        data_sources = ['yaml:c:datasources/nested.yaml',
+                        'yaml:datasources/b.yaml',
+                        'yaml:datasources/a.yaml']
+
+        self.datasource_collection = DataSourceCollection(data_sources)
+        self.preprocessor = Preprocessor(self.datasource_collection, 'us-east-1')
+
+    def test_resolve_template_parameters(self):
+        template = TemplateLoader.load_templates(['templates/simpletemplate.yaml'])
+        parameters = Cloudformation.resolve_template_parameters(template, self.datasource_collection)
+
+        self.assertEqual(parameters['a_list'], 'item1, item2, item3, item4')
+        self.assertEqual(parameters['b_list'], '1, 2, 3')
+
+    def test_invalid_function(self):
+        self.assertRaises(InvalidPreprocessorFunctionException, self.preprocessor.process, {'Rb::NoSuchFunction': ''})

--- a/tests/test_datasources.py
+++ b/tests/test_datasources.py
@@ -59,14 +59,14 @@ class TestDataSources(TestCase):
             )
 
     def test_list(self):
-        self.assertEqual(
+        self.assertListEqual(
             self.datasource_collection.get_parameter_recursive('a_list'),
-            'item1, item2, item3, item4'
+            ['item1', 'item2', 'item3', 'item4']
         )
 
-        self.assertEqual(
+        self.assertListEqual(
             self.datasource_collection.get_parameter_recursive('b_list'),
-            '1, 2, 3'
+            [1, 2, 3]
         )
 
     def test_override(self):

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -21,10 +21,12 @@ class TestPreprocessor(TestCase):
     def test_instance_chooser(self):
         with open('preprocessor/instance_chooser1.yaml') as instance_chooser1, \
                 open('preprocessor/instance_chooser2.yaml') as instance_chooser2, \
-                open('preprocessor/instance_chooser3.yaml') as instance_chooser3:
+                open('preprocessor/instance_chooser3.yaml') as instance_chooser3, \
+                open('preprocessor/instance_chooser4.yaml') as instance_chooser4:
             template = RainbowYamlLoader(instance_chooser1).get_data()
             template2 = RainbowYamlLoader(instance_chooser2).get_data()
             template3 = RainbowYamlLoader(instance_chooser3).get_data()
+            template4 = RainbowYamlLoader(instance_chooser4).get_data()
 
         processed = self.preprocessor.process(template)
         self.assertEqual(processed['Resources']['Properties']['InstanceType'], 'c1.xlarge')
@@ -33,6 +35,9 @@ class TestPreprocessor(TestCase):
         self.assertEqual(processed2['Resources']['Properties']['InstanceType'], 'c3.large')
 
         self.assertRaises(InvalidInstanceException, self.preprocessor.process, template3)
+
+        processed4 = self.preprocessor.process(template4)
+        self.assertEqual(processed4['Resources']['Properties']['InstanceType'], 'c3.large')
 
     def test_invalid_function(self):
         self.assertRaises(InvalidPreprocessorFunctionException, self.preprocessor.process, {'Rb::NoSuchFunction': ''})


### PR DESCRIPTION
- DataCollection.get_parameter_recursive will not join lists into strings
- Fixed Rb::InstanceChooser not to accept a string parameter, only lists
- Fixed a bug where Rb::InstanceChooser didn't handle pointers to lists
  properly
