### PR TITLE
handling rate exceeded messages

### DIFF
--- a/rainbow/cloudformation.py
+++ b/rainbow/cloudformation.py
@@ -215,9 +215,8 @@ class Cloudformation(object):
 
         previous_stack_events = initial_entry
 
-        stack = self.describe_stack(name)
-
         while True:
+            stack = self.describe_stack(name)
             stack_events = self.describe_stack_events(name)
 
             if len(stack_events) > previous_stack_events:

--- a/rainbow/cloudformation.py
+++ b/rainbow/cloudformation.py
@@ -165,7 +165,7 @@ class Cloudformation(object):
         :rtype: list of boto.cloudformation.stack.StackEvent
         """
 
-        return with_boto_retries(boto_all, self.connection.describe_stack_events, name)
+        return self.with_boto_retries(boto_all, self.connection.describe_stack_events, name)
 
     def describe_stack(self, name):
         """
@@ -176,7 +176,7 @@ class Cloudformation(object):
         :rtype: boto.cloudformation.stack.Stack
         """
 
-        return with_boto_retries(self.connection.describe_stacks, name)[0]
+        return self.with_boto_retries(self.connection.describe_stacks, name)[0]
 
     def tail_stack_events(self, name, initial_entry=None):
         """

--- a/rainbow/cloudformation.py
+++ b/rainbow/cloudformation.py
@@ -149,10 +149,9 @@ class Cloudformation(object):
             try:
                 return action(*args)
             except boto.exception.BotoServerError, details:
-                if details.message == u'Rate exceeded':
-                    retries += 1
-                else:
+                if details.message != u'Rate exceeded':
                     raise
+                retries += 1
             time.sleep(min(pow(2, retries), max_sleep_time))
 
     def describe_stack_events(self, name):


### PR DESCRIPTION
We're using this to do multiple stack deployments at once from a single server, and running into AWS rate limiting. This is the recommended fix as per http://docs.aws.amazon.com/general/latest/gr/api-retries.html - tested and confirmed working for us.
